### PR TITLE
redis: introduce ConnWithContext

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,34 +1,34 @@
 Redigo
 ======
 
-[![Build Status](https://travis-ci.org/gomodule/redigo.svg?branch=master)](https://travis-ci.org/gomodule/redigo)
-[![GoDoc](https://godoc.org/github.com/gomodule/redigo/redis?status.svg)](https://godoc.org/github.com/gomodule/redigo/redis)
+[![Build Status](https://travis-ci.org/opencensus-integrations/redigo.svg?branch=master)](https://travis-ci.org/opencensus-integrations/redigo)
+[![GoDoc](https://godoc.org/github.com/opencensus-integrations/redigo/redis?status.svg)](https://godoc.org/github.com/opencensus-integrations/redigo/redis)
 
 Redigo is a [Go](http://golang.org/) client for the [Redis](http://redis.io/) database.
 
 Features
 -------
 
-* A [Print-like](http://godoc.org/github.com/gomodule/redigo/redis#hdr-Executing_Commands) API with support for all Redis commands.
-* [Pipelining](http://godoc.org/github.com/gomodule/redigo/redis#hdr-Pipelining), including pipelined transactions.
-* [Publish/Subscribe](http://godoc.org/github.com/gomodule/redigo/redis#hdr-Publish_and_Subscribe).
-* [Connection pooling](http://godoc.org/github.com/gomodule/redigo/redis#Pool).
-* [Script helper type](http://godoc.org/github.com/gomodule/redigo/redis#Script) with optimistic use of EVALSHA.
-* [Helper functions](http://godoc.org/github.com/gomodule/redigo/redis#hdr-Reply_Helpers) for working with command replies.
+* A [Print-like](http://godoc.org/github.com/opencensus-integrations/redigo/redis#hdr-Executing_Commands) API with support for all Redis commands.
+* [Pipelining](http://godoc.org/github.com/opencensus-integrations/redigo/redis#hdr-Pipelining), including pipelined transactions.
+* [Publish/Subscribe](http://godoc.org/github.com/opencensus-integrations/redigo/redis#hdr-Publish_and_Subscribe).
+* [Connection pooling](http://godoc.org/github.com/opencensus-integrations/redigo/redis#Pool).
+* [Script helper type](http://godoc.org/github.com/opencensus-integrations/redigo/redis#Script) with optimistic use of EVALSHA.
+* [Helper functions](http://godoc.org/github.com/opencensus-integrations/redigo/redis#hdr-Reply_Helpers) for working with command replies.
 
 Documentation
 -------------
 
-- [API Reference](http://godoc.org/github.com/gomodule/redigo/redis)
-- [FAQ](https://github.com/gomodule/redigo/wiki/FAQ)
-- [Examples](https://godoc.org/github.com/gomodule/redigo/redis#pkg-examples)
+- [API Reference](http://godoc.org/github.com/opencensus-integrations/redigo/redis)
+- [FAQ](https://github.com/opencensus-integrations/redigo/wiki/FAQ)
+- [Examples](https://godoc.org/github.com/opencensus-integrations/redigo/redis#pkg-examples)
 
 Installation
 ------------
 
 Install Redigo using the "go get" command:
 
-    go get github.com/gomodule/redigo/redis
+    go get github.com/opencensus-integrations/redigo/redis
 
 The Go distribution is Redigo's only dependency.
 
@@ -43,7 +43,7 @@ Related Projects
 Contributing
 ------------
 
-See [CONTRIBUTING.md](https://github.com/gomodule/redigo/blob/master/.github/CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/opencensus-integrations/redigo/blob/master/.github/CONTRIBUTING.md).
 
 License
 -------

--- a/internal/commandinfo.go
+++ b/internal/commandinfo.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-package internal // import "github.com/gomodule/redigo/internal"
+package internal // import "github.com/opencensus-integrations/redigo/internal"
 
 import (
 	"strings"

--- a/internal/redistest/testdb.go
+++ b/internal/redistest/testdb.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 type testConn struct {

--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 type testConn struct {

--- a/redis/doc.go
+++ b/redis/doc.go
@@ -14,7 +14,7 @@
 
 // Package redis is a client for the Redis database.
 //
-// The Redigo FAQ (https://github.com/gomodule/redigo/wiki/FAQ) contains more
+// The Redigo FAQ (https://github.com/opencensus-integrations/redigo/wiki/FAQ) contains more
 // documentation about this package.
 //
 // Connections
@@ -174,4 +174,4 @@
 // non-recoverable error such as a network error or protocol parsing error. If
 // Err() returns a non-nil value, then the connection is not usable and should
 // be closed.
-package redis // import "github.com/gomodule/redigo/redis"
+package redis // import "github.com/opencensus-integrations/redigo/redis"

--- a/redis/observability.go
+++ b/redis/observability.go
@@ -14,6 +14,6 @@
 
 package redis
 
-import "github.com/gomodule/redigo/internal/observability"
+import "github.com/opencensus-integrations/redigo/internal/observability"
 
 var ObservabilityMetricViews = observability.Views

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -26,8 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gomodule/redigo/internal"
-	"github.com/gomodule/redigo/internal/observability"
+	"github.com/opencensus-integrations/redigo/internal"
+	"github.com/opencensus-integrations/redigo/internal/observability"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
@@ -35,7 +35,9 @@ import (
 
 var (
 	_ ConnWithTimeout = (*activeConn)(nil)
+	_ ConnWithContext = (*activeConn)(nil)
 	_ ConnWithTimeout = (*errorConn)(nil)
+	_ ConnWithContext = (*errorConn)(nil)
 )
 
 var nowFunc = time.Now // for testing
@@ -377,7 +379,11 @@ func (p *Pool) put(ctx context.Context, pc *poolConn, forceClose bool) error {
 
 	if pc != nil {
 		p.mu.Unlock()
-		pc.c.Close()
+		if cctx, ok := pc.c.(ConnWithContext); ok {
+			cctx.CloseContext(ctx)
+		} else {
+			pc.c.Close()
+		}
 		p.mu.Lock()
 		p.active--
 	}
@@ -422,12 +428,16 @@ func initSentinel() {
 }
 
 func (ac *activeConn) Close() error {
+	return ac.CloseContext(context.Background())
+}
+
+func (ac *activeConn) CloseContext(ctx context.Context) error {
 	pc := ac.pc
 	if pc == nil {
 		return nil
 	}
 	ac.pc = nil
-	stats.Record(ac.context(), observability.MConnectionsClosed.M(1))
+	stats.Record(ctx, observability.MConnectionsClosed.M(1))
 
 	if ac.state&internal.MultiState != 0 {
 		pc.c.Send("DISCARD")
@@ -456,7 +466,7 @@ func (ac *activeConn) Close() error {
 		}
 	}
 	pc.c.Do("")
-	ac.p.put(ac.context(), pc, ac.state != 0 || pc.c.Err() != nil)
+	ac.p.put(ctx, pc, ac.state != 0 || pc.c.Err() != nil)
 	return nil
 }
 
@@ -468,20 +478,20 @@ func (ac *activeConn) Err() error {
 	return pc.c.Err()
 }
 
-type contextAwareDoer interface {
-	DoWithContext(context.Context, string, ...interface{}) (interface{}, error)
+func (ac *activeConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	return ac.DoContext(context.Background(), commandName, args...)
 }
 
-func (ac *activeConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+func (ac *activeConn) DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error) {
 	pc := ac.pc
 	if pc == nil {
 		return nil, errConnClosed
 	}
 	ci := internal.LookupCommandInfo(commandName)
 	ac.state = (ac.state | ci.Set) &^ ci.Clear
-	cwdoer, ok := pc.c.(contextAwareDoer)
+	cwdoer, ok := pc.c.(ConnWithContext)
 	if ok {
-		return cwdoer.DoWithContext(ac.context(), commandName, args...)
+		return cwdoer.DoContext(ctx, commandName, args...)
 	}
 	return pc.c.Do(commandName, args...)
 }
@@ -501,29 +511,53 @@ func (ac *activeConn) DoWithTimeout(timeout time.Duration, commandName string, a
 }
 
 func (ac *activeConn) Send(commandName string, args ...interface{}) error {
+	return ac.SendContext(context.Background(), commandName, args...)
+}
+
+func (ac *activeConn) SendContext(ctx context.Context, commandName string, args ...interface{}) error {
 	pc := ac.pc
 	if pc == nil {
 		return errConnClosed
 	}
 	ci := internal.LookupCommandInfo(commandName)
 	ac.state = (ac.state | ci.Set) &^ ci.Clear
-	return pc.c.Send(commandName, args...)
+	if cctx, ok := pc.c.(ConnWithContext); ok {
+		return cctx.SendContext(ctx, commandName, args...)
+	} else {
+		return pc.c.Send(commandName, args...)
+	}
 }
 
 func (ac *activeConn) Flush() error {
+	return ac.FlushContext(context.Background())
+}
+
+func (ac *activeConn) FlushContext(ctx context.Context) error {
 	pc := ac.pc
 	if pc == nil {
 		return errConnClosed
 	}
-	return pc.c.Flush()
+	if cctx, ok := pc.c.(ConnWithContext); ok {
+		return cctx.FlushContext(ctx)
+	} else {
+		return pc.c.Flush()
+	}
 }
 
 func (ac *activeConn) Receive() (reply interface{}, err error) {
+	return ac.ReceiveContext(context.Background())
+}
+
+func (ac *activeConn) ReceiveContext(ctx context.Context) (reply interface{}, err error) {
 	pc := ac.pc
 	if pc == nil {
 		return nil, errConnClosed
 	}
-	return pc.c.Receive()
+	if cctx, ok := pc.c.(ConnWithContext); ok {
+		return cctx.ReceiveContext(ctx)
+	} else {
+		return pc.c.Receive()
+	}
 }
 
 func (ac *activeConn) ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err error) {
@@ -541,18 +575,22 @@ func (ac *activeConn) ReceiveWithTimeout(timeout time.Duration) (reply interface
 type errorConn struct{ err error }
 
 func (ec errorConn) Do(string, ...interface{}) (interface{}, error) { return nil, ec.err }
-func (ec errorConn) DoWithContext(context.Context, string, ...interface{}) (interface{}, error) {
+func (ec errorConn) DoContext(context.Context, string, ...interface{}) (interface{}, error) {
 	return nil, ec.err
 }
 func (ec errorConn) DoWithTimeout(time.Duration, string, ...interface{}) (interface{}, error) {
 	return nil, ec.err
 }
-func (ec errorConn) Send(string, ...interface{}) error                     { return ec.err }
-func (ec errorConn) Err() error                                            { return ec.err }
-func (ec errorConn) Close() error                                          { return nil }
-func (ec errorConn) Flush() error                                          { return ec.err }
-func (ec errorConn) Receive() (interface{}, error)                         { return nil, ec.err }
-func (ec errorConn) ReceiveWithTimeout(time.Duration) (interface{}, error) { return nil, ec.err }
+func (ec errorConn) Send(string, ...interface{}) error                         { return ec.err }
+func (ec errorConn) SendContext(context.Context, string, ...interface{}) error { return ec.err }
+func (ec errorConn) Err() error                                                { return ec.err }
+func (ec errorConn) Close() error                                              { return nil }
+func (ec errorConn) CloseContext(context.Context) error                        { return nil }
+func (ec errorConn) Flush() error                                              { return ec.err }
+func (ec errorConn) FlushContext(context.Context) error                        { return ec.err }
+func (ec errorConn) Receive() (interface{}, error)                             { return nil, ec.err }
+func (ec errorConn) ReceiveContext(context.Context) (interface{}, error)       { return nil, ec.err }
+func (ec errorConn) ReceiveWithTimeout(time.Duration) (interface{}, error)     { return nil, ec.err }
 
 type idleList struct {
 	count       int

--- a/redis/pool17_test.go
+++ b/redis/pool17_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 func TestWaitPoolGetContext(t *testing.T) {

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 type poolTestConn struct {

--- a/redis/pubsub_example_test.go
+++ b/redis/pubsub_example_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 // listenPubSubChannels listens for messages on Redis pubsub channels. The

--- a/redis/pubsub_test.go
+++ b/redis/pubsub_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 func expectPushed(t *testing.T, c redis.PubSubConn, message string, expected interface{}) {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -15,6 +15,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -43,6 +44,25 @@ type Conn interface {
 
 	// Receive receives a single reply from the Redis server
 	Receive() (reply interface{}, err error)
+}
+
+type ConnWithContext interface {
+	Conn
+
+	// CloseContext closes the connection.
+	CloseContext(context.Context) error
+
+	// DoContext sends a command to the server and returns the received reply.
+	DoContext(ctx context.Context, commandName string, args ...interface{}) (reply interface{}, err error)
+
+	// SendContext writes the command to the client's output buffer.
+	SendContext(ctx context.Context, commandName string, args ...interface{}) error
+
+	// FlushContext flushes the output buffer to the Redis server.
+	FlushContext(context.Context) error
+
+	// ReceiveContext receives a single reply from the Redis server
+	ReceiveContext(context.Context) (reply interface{}, err error)
 }
 
 // Argument is the interface implemented by an object which wants to control how

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 type timeoutTestConn int

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 type valueError struct {

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 type durationScan struct {

--- a/redis/script_test.go
+++ b/redis/script_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 var (

--- a/redis/zpop_example_test.go
+++ b/redis/zpop_example_test.go
@@ -17,7 +17,7 @@ package redis_test
 import (
 	"fmt"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 // zpop pops a value from the ZSET key using WATCH/MULTI/EXEC commands.

--- a/redisx/connmux.go
+++ b/redisx/connmux.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/gomodule/redigo/internal"
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/internal"
+	"github.com/opencensus-integrations/redigo/redis"
 )
 
 // ConnMux multiplexes one or more connections to a single underlying

--- a/redisx/doc.go
+++ b/redisx/doc.go
@@ -14,4 +14,4 @@
 
 // Package redisx contains experimental features for Redigo. Features in this
 // package may be modified or deleted at any time.
-package redisx // import "github.com/gomodule/redigo/redisx"
+package redisx // import "github.com/opencensus-integrations/redigo/redisx"


### PR DESCRIPTION
To enable context propagation for distributed tracing
and monitoring but also for backwards compatibility
with older programs, this change introduces `ConnWithContext`
which is an interface that implements `Conn` but introduces
`Conn` methods that are suffixed with `Context` and take in
`context.Context` as the first argument. For example:
* DoContext(context.Context, ...)
* CloseContext(context.Context)
* SendContext(context.Context, ...)
* FlushContext(context.Context)
* ReceiveContext(context.Context)

If the `Context` suffixed methods are not used, `context.Background()`
is passed by the underlying implementations of `*activeConn` and `*conn`.

Once you've retrieved a `Conn`, from the pool, type assert on it
with `ConnContext` e.g.

    conn := redisPool.GetWithContext(ctx).(redis.ConnWithContext)
    defer conn.CloseContext(ctx)